### PR TITLE
Patching publishing again

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -5,7 +5,7 @@ permissions:
   pull-requests: write
   statuses: write
   id-token: write
-"on":
+on:
   push:
     branches:
       - main
@@ -23,4 +23,3 @@ jobs:
       java_gpg_secret_key: ${{ secrets.JAVA_GPG_SECRET_KEY }}
       ossrh_password: ${{ secrets.OSSRH_PASSWORD }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
-      SHIPPO_TOKEN: ${{ secrets.SHIPPO_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_DIR=./build/
 LOCAL_SPEC_FILE=${BUILD_DIR}public-api.yaml
 
-check: build test
+check: test
 
 clean:
 	rm -rf ./build
@@ -10,7 +10,7 @@ build:
 	./gradlew build
 
 test:
-	./gradlew test
+	./gradlew test -PrunTests
 
 speakeasy-install: # dev task, locally install the speakeasy CLI
 	brew install speakeasy-api/homebrew-tap/speakeasy

--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -2,6 +2,15 @@
 // * is referred to in an `apply from` command in `build.gradle`
 // * can be used to customise `build.gradle`
 // * is generated once and not overwritten in SDK generation updates
+
+// Disable tests for publishing b/c we run tests in pipeline already
+// TODO: Find better alternative
+tasks.named('test') {
+    onlyIf {
+        project.hasProperty('runTests')
+    }
+}
+
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'


### PR DESCRIPTION
Token cannot be passed into publishing to fix tests.

We run tests prior to merge anyway, so no point in re-running as part of publishing step.